### PR TITLE
Fix tooltip and config

### DIFF
--- a/yield.html
+++ b/yield.html
@@ -4,7 +4,7 @@
     color: '#66ccff',
     defaults: {
       name: {value:""}
-    }
+    },
     inputs:1,
     outputs:1,
     icon: "bridge.png",

--- a/yield.html
+++ b/yield.html
@@ -2,27 +2,29 @@
   RED.nodes.registerType('yield',{
     category: 'function',
     color: '#66ccff',
+    defaults: {
+      name: {value:""}
+    }
     inputs:1,
     outputs:1,
+    icon: "bridge.png",
     label: function() {
       return 'yield'
     },
   })
 </script>
 
-<!--
 <script type="text/x-red" data-template-name="yield">
     <div class="form-row">
         <label for="node-input-name"><i class="icon-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name">
     </div>
 </script>
--->
 
 <script type="text/x-red" data-help-name="yield">
-    <p>Description</p>
     <p>
     This node sends messages passed from <code>msg.payload</code> separately
-    down the flow. Simply puts the messages in an array and assign to <code>msg.payload</code>.
+    down the flow.</p>
+    <p>Simply put the messages in an array and assign to <code>msg.payload</code>.
     </p>
 </script>


### PR DESCRIPTION
First sentence in help is used as a tooltip.  Fix makes this descriptive.

Lack if config template section causes Node-Red to display the last used config layout from another node.  Should allow name to be set at a minimum.

Added an icon
